### PR TITLE
conda build support on the mac

### DIFF
--- a/rdkit/build.sh
+++ b/rdkit/build.sh
@@ -4,6 +4,7 @@
 
 $PYTHON "$RECIPE_DIR/fetch_inchi.py"
 $PYTHON "$RECIPE_DIR/fetch_avalontools.py"
+PY_INC=`$PYTHON -c "from distutils import sysconfig; print (sysconfig.get_python_inc(0, '$PREFIX'))"`
 
 cmake \
     -D RDK_INSTALL_INTREE=OFF \
@@ -16,7 +17,7 @@ cmake \
     -D CMAKE_INSTALL_PREFIX=$PREFIX \
     -D Python_ADDITIONAL_VERSIONS=${PY_VER} \
     -D PYTHON_EXECUTABLE=$PYTHON \
-    -D PYTHON_INCLUDE_DIR=$PREFIX/include/python3.4m \
+    -D PYTHON_INCLUDE_DIR=${PY_INC} \
     -D PYTHON_NUMPY_INCLUDE_PATH=$SP_DIR/numpy/core/include \
     -D BOOST_ROOT=$PREFIX -D Boost_NO_SYSTEM_PATHS=ON \
     -D CMAKE_BUILD_TYPE=Release \

--- a/rdkit/meta.yaml
+++ b/rdkit/meta.yaml
@@ -16,8 +16,8 @@ requirements:
     - cmake [linux]
     - cmake <=2.8.9 [osx]
     - requests
-    - python
     - boost
+    - python
     - numpy
     - pil [py2k]
     - pillow [py3k]


### PR DESCRIPTION
This works for me with python2.7 and python3.4 on the Mac.

@rvianello: do these changes look ok to you? 
