### PR TITLE
comment out empty build block

### DIFF
--- a/cairocffi/meta.yaml
+++ b/cairocffi/meta.yaml
@@ -6,7 +6,7 @@ source:
   git_url: https://github.com/SimonSapin/cairocffi.git
   git_tag:
 
-build:
+# build:
   #number: 0
 
 requirements:


### PR DESCRIPTION
This was causing errors with recent conda versions.