### PR TITLE
explicit avalon and inchi pulls no longer required; bump version

### DIFF
--- a/rdkit/build.sh
+++ b/rdkit/build.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-$PYTHON "$RECIPE_DIR/fetch_inchi.py"
-$PYTHON "$RECIPE_DIR/fetch_avalontools.py"
 PY_INC=`$PYTHON -c "from distutils import sysconfig; print (sysconfig.get_python_inc(0, '$PREFIX'))"`
 
 cmake \
@@ -12,7 +10,6 @@ cmake \
     -D RDK_USE_FLEXBISON=OFF \
     -D RDK_BUILD_THREADSAFE_SSS=ON \
     -D RDK_TEST_MULTITHREADED=ON \
-    -D AVALONTOOLS_DIR=$SRC_DIR/External/AvalonTools/src/SourceDistribution \
     -D CMAKE_SYSTEM_PREFIX_PATH=$PREFIX \
     -D CMAKE_INSTALL_PREFIX=$PREFIX \
     -D Python_ADDITIONAL_VERSIONS=${PY_VER} \

--- a/rdkit/meta.yaml
+++ b/rdkit/meta.yaml
@@ -4,7 +4,7 @@ package:
 
 source:
   git_url: https://github.com/rdkit/rdkit.git
-  git_tag: Release_2015_09_2
+  git_tag: Release_2016_03_1
   patches:
     - rdpaths.patch
     - rdconfig.patch [win]


### PR DESCRIPTION
I was planning on doing this as two separate PRs, but since I made the changes on master, they got merged into one.
Both are very small, so hopefully this isn't too disturbing.
