### PR TITLE
update to Release_2016_03_4

### DIFF
--- a/rdkit-postgresql/meta.yaml
+++ b/rdkit-postgresql/meta.yaml
@@ -4,7 +4,7 @@ package:
 
 source:
   git_url: https://github.com/rdkit/rdkit.git
-  git_tag: Release_2016_03_3
+  git_tag: Release_2016_03_4
   patches:
     - Makefile.patch
     - adapter.cpp.patch
@@ -15,11 +15,11 @@ build:
 requirements:
   build:
     - python
-    - rdkit >=2016.03.3
+    - rdkit >=2016.03.4,<2016.09
     - postgresql >=9.4,<9.5
   run:
     - python
-    - rdkit >=2016.03.3
+    - rdkit >=2016.03.4,<2016.09
     - postgresql >=9.4,<9.5
 
 about:

--- a/rdkit-postgresql95/meta.yaml
+++ b/rdkit-postgresql95/meta.yaml
@@ -4,7 +4,7 @@ package:
 
 source:
   git_url: https://github.com/rdkit/rdkit.git
-  git_tag: Release_2016_03_3
+  git_tag: Release_2016_03_4
   patches:
     - Makefile.patch
     - adapter.cpp.patch
@@ -15,11 +15,11 @@ build:
 requirements:
   build:
     - python
-    - rdkit >=2016.03.3
+    - rdkit >=2016.03.4,<2016.09
     - postgresql95
   run:
     - python
-    - rdkit >=2016.03.3
+    - rdkit >=2016.03.4,<2016.09
     - postgresql95
 
 about:

--- a/rdkit/meta.yaml
+++ b/rdkit/meta.yaml
@@ -4,7 +4,7 @@ package:
 
 source:
   git_url: https://github.com/rdkit/rdkit.git
-  git_tag: Release_2016_03_3
+  git_tag: Release_2016_03_4
   patches:
     - rdpaths.patch
     - rdconfig.patch [win]


### PR DESCRIPTION
updates the rdkit and rdkit-postgres* recipes to build the current patch release.