### PR TITLE
Update to 2016 09 2

### DIFF
--- a/rdkit-postgresql/Makefile.patch
+++ b/rdkit-postgresql/Makefile.patch
@@ -1,8 +1,8 @@
-diff --git a/Code/PgSQL/rdkit/Makefile b/Code/PgSQL/rdkit/Makefile
-index 73c1f1a..b6953eb 100644
---- a/Code/PgSQL/rdkit/Makefile
-+++ b/Code/PgSQL/rdkit/Makefile
-@@ -11,28 +11,31 @@
+diff --git Code/PgSQL/rdkit/Makefile Code/PgSQL/rdkit/Makefile
+index 7cce682..b6953eb 100644
+--- Code/PgSQL/rdkit/Makefile
++++ Code/PgSQL/rdkit/Makefile
+@@ -11,25 +11,28 @@
  # -------------------------
  
  
@@ -34,11 +34,7 @@ index 73c1f1a..b6953eb 100644
 +  THREADLIBS=-lboost_thread -lboost_system
  endif
  
--RDKLIBS       = ${AVALONLIBS} ${INCHILIBS} -lMolHash -lFMCS -lChemReactions -lChemTransforms -lFileParsers -lSmilesParse -lFingerprints -lSubgraphs -lDescriptors -lPartialCharges -lSubstructMatch  -lGraphMol -lDataStructs -lDepictor -lRDGeometryLib -lRDGeneral
-+RDKLIBS       = ${AVALONLIBS} ${INCHILIBS} -lMolDraw2D -lMolTransforms -lMolHash -lFMCS -lChemReactions -lChemTransforms -lFileParsers -lSmilesParse -lFingerprints -lSubgraphs -lDescriptors -lPartialCharges -lSubstructMatch  -lGraphMol -lEigenSolvers -lDataStructs -lDepictor -lRDGeometryLib -lRDGeneral
- 
- ifeq ($(STATIC_LINK),0)
-   SHLIB_LINK += -L${RDKIT}/lib -Wl,-rpath,'${RDKIT}/lib' ${RDKLIBS}
+ RDKLIBS       = ${AVALONLIBS} ${INCHILIBS} -lMolDraw2D -lMolTransforms -lMolHash -lFMCS -lChemReactions -lChemTransforms -lFileParsers -lSmilesParse -lFingerprints -lSubgraphs -lDescriptors -lPartialCharges -lSubstructMatch  -lGraphMol -lEigenSolvers -lDataStructs -lDepictor -lRDGeometryLib -lRDGeneral
 @@ -40,14 +43,11 @@ else
    SHLIB_LINK += -L${RDKIT}/lib $(addsuffix _static,${RDKLIBS})
  endif

--- a/rdkit-postgresql/meta.yaml
+++ b/rdkit-postgresql/meta.yaml
@@ -4,7 +4,7 @@ package:
 
 source:
   git_url: https://github.com/rdkit/rdkit.git
-  git_tag: Release_2016_09_1
+  git_tag: Release_2016_09_2
   patches:
     - Makefile.patch
     - adapter.cpp.patch

--- a/rdkit-postgresql95/Makefile.patch
+++ b/rdkit-postgresql95/Makefile.patch
@@ -1,8 +1,8 @@
-diff --git a/Code/PgSQL/rdkit/Makefile b/Code/PgSQL/rdkit/Makefile
-index 73c1f1a..b6953eb 100644
---- a/Code/PgSQL/rdkit/Makefile
-+++ b/Code/PgSQL/rdkit/Makefile
-@@ -11,28 +11,31 @@
+diff --git Code/PgSQL/rdkit/Makefile Code/PgSQL/rdkit/Makefile
+index 7cce682..b6953eb 100644
+--- Code/PgSQL/rdkit/Makefile
++++ Code/PgSQL/rdkit/Makefile
+@@ -11,25 +11,28 @@
  # -------------------------
  
  
@@ -34,11 +34,7 @@ index 73c1f1a..b6953eb 100644
 +  THREADLIBS=-lboost_thread -lboost_system
  endif
  
--RDKLIBS       = ${AVALONLIBS} ${INCHILIBS} -lMolHash -lFMCS -lChemReactions -lChemTransforms -lFileParsers -lSmilesParse -lFingerprints -lSubgraphs -lDescriptors -lPartialCharges -lSubstructMatch  -lGraphMol -lDataStructs -lDepictor -lRDGeometryLib -lRDGeneral
-+RDKLIBS       = ${AVALONLIBS} ${INCHILIBS} -lMolDraw2D -lMolTransforms -lMolHash -lFMCS -lChemReactions -lChemTransforms -lFileParsers -lSmilesParse -lFingerprints -lSubgraphs -lDescriptors -lPartialCharges -lSubstructMatch  -lGraphMol -lEigenSolvers -lDataStructs -lDepictor -lRDGeometryLib -lRDGeneral
- 
- ifeq ($(STATIC_LINK),0)
-   SHLIB_LINK += -L${RDKIT}/lib -Wl,-rpath,'${RDKIT}/lib' ${RDKLIBS}
+ RDKLIBS       = ${AVALONLIBS} ${INCHILIBS} -lMolDraw2D -lMolTransforms -lMolHash -lFMCS -lChemReactions -lChemTransforms -lFileParsers -lSmilesParse -lFingerprints -lSubgraphs -lDescriptors -lPartialCharges -lSubstructMatch  -lGraphMol -lEigenSolvers -lDataStructs -lDepictor -lRDGeometryLib -lRDGeneral
 @@ -40,14 +43,11 @@ else
    SHLIB_LINK += -L${RDKIT}/lib $(addsuffix _static,${RDKLIBS})
  endif

--- a/rdkit-postgresql95/meta.yaml
+++ b/rdkit-postgresql95/meta.yaml
@@ -4,7 +4,7 @@ package:
 
 source:
   git_url: https://github.com/rdkit/rdkit.git
-  git_tag: Release_2016_09_1
+  git_tag: Release_2016_09_2
   patches:
     - Makefile.patch
     - adapter.cpp.patch

--- a/rdkit/meta.yaml
+++ b/rdkit/meta.yaml
@@ -4,7 +4,7 @@ package:
 
 source:
   git_url: https://github.com/rdkit/rdkit.git
-  git_tag: Release_2016_09_1
+  git_tag: Release_2016_09_2
   patches:
     - rdpaths.patch
     - rdconfig.patch [win]

--- a/rdkit/rdconfig.patch
+++ b/rdkit/rdconfig.patch
@@ -4,16 +4,16 @@ index 9b685e2..7d022d5 100755
 +++ rdkit/RDConfig.py
 @@ -25,11 +25,11 @@ elif 'CONDA_DEFAULT_ENV' in os.environ:
    # we are running in a conda environ.
-   RDCodeDir=os.path.dirname(__file__)
+   RDCodeDir = os.path.dirname(__file__)
    splitdir = RDCodeDir.split(os.path.sep)
 -  condaDir = splitdir[:-4]
 +  condaDir = splitdir[:-3]
-   if condaDir[0]=='':
+   if condaDir[0] == '':
      condaDir[0] = os.path.sep
--  condaDir += ['share','RDKit']
+-  condaDir += ['share', 'RDKit']
 -  _share = os.path.join(*condaDir)
 +  condaDir += ['Library','share','RDKit']
 +  _share = os.path.sep.join(condaDir)
-   RDDataDir=os.path.join(_share,'Data')
-   RDDocsDir=os.path.join(_share,'Docs')
-   RDProjDir=os.path.join(_share,'Projects')
+   RDDataDir = os.path.join(_share, 'Data')
+   RDDocsDir = os.path.join(_share, 'Docs')
+   RDProjDir = os.path.join(_share, 'Projects')


### PR DESCRIPTION
@greglandrum this one should align the master branch to the current release. I didn't yet run the full centos6 build using the Dockerfile, I verified the rdkit* recipes on my fedora box and the rdkit one on windows x86_64 for py2.7 and py3.5