### PR TITLE
- enable conda-rdkit builds on all platforms

### DIFF
--- a/boost/bld.bat
+++ b/boost/bld.bat
@@ -16,14 +16,14 @@ set BZIP2_LIBPATH=%PREFIX%\lib
 set ZLIB_INCLUDE=%PREFIX%\include
 set ZLIB_LIBPATH=%PREFIX%\lib
 
-if "%PKG_VERSION%"=="1.56.0" ( 
-	set BOOST_DIR=%SRC_DIR%\boost_1_56_0 
-) else if  "%PKG_VERSION%"=="1.59.0" ( 
-	set BOOST_DIR=%SRC_DIR%\boost_1_59_0
-) else (
-	echo "Unexpected version of boost"
-	exit 1
-) 
+if "%PKG_VERSION%" neq "1.56.0" (
+  if "%PKG_VERSION%" neq "1.59.0" (
+    echo "Unexpected version of boost"
+    exit 1
+  )
+)
+
+set BOOST_DIR=%SRC_DIR%
 
 set STAGE_DIR="%BOOST_DIR%\stage"
 

--- a/boost/build.sh
+++ b/boost/build.sh
@@ -30,17 +30,11 @@ echo "     : $PREFIX/lib" >> ./project-config.jam
 echo "     ;" >> ./project-config.jam
 
 
-# on the Mac, using py34 with at least conda 3.7.3 requires a symlink for the shared library:
-if [ $OSX_ARCH == "x86_64" -a $PY_VER == "3.4" ]; then
+# on the Mac, using py > 3.0 with at least conda 3.7.3 requires a symlink for the shared library:
+if [ "$OSX_ARCH" == "x86_64" ] && ( echo $PY_VER | awk '{exit ($1 > 3.0 ? 0 : 1)}' ); then
   tmpd=$PWD
   cd $PREFIX/lib
-  ln -s libpython3.4m.dylib libpython3.4.dylib
-  cd $tmpd
-fi
-if [ $OSX_ARCH == "x86_64" -a $PY_VER == "3.5" ]; then
-  tmpd=$PWD
-  cd $PREFIX/lib
-  ln -s libpython3.5m.dylib libpython3.5.dylib
+  ln -s libpython${PY_VER}m.dylib libpython${PY_VER}.dylib
   cd $tmpd
 fi
 ./b2 -q install \

--- a/postgresql/bld.bat
+++ b/postgresql/bld.bat
@@ -1,0 +1,3 @@
+cd %SRC_DIR%\src\tools\msvc
+call build
+call install "%LIBRARY_PREFIX%"

--- a/postgresql/build.sh
+++ b/postgresql/build.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
 
+# this is required to get the build to work on OS X
+if [ "$OSX_ARCH" == "x86_64" ]; then
+  export LDFLAGS="$LDFLAGS -Wl,-rpath,$PREFIX/lib"
+  install_name_tool -id "@rpath/libreadline.6.2.dylib" $PREFIX/lib/libreadline.6.2.dylib
+fi
 ./configure \
     --prefix=$PREFIX       \
     --with-includes=$PREFIX/include \
@@ -17,6 +22,10 @@ make install
 
 pushd contrib
 make -j$CPU_COUNT
+# make check may fail because of unix socket names
+# being too long depending on the length of the path
+# where anaconda is installed
+# add an --ignore-errors if this is the case
 make check
 make install
 popd

--- a/postgresql/meta.yaml
+++ b/postgresql/meta.yaml
@@ -7,7 +7,7 @@ source:
   url: https://ftp.postgresql.org/pub/source/v9.4.4/postgresql-9.4.4.tar.bz2
   md5: 1fe952c44ed26d7e6a335cf991a9c1c6
   patches:
-    - prefer_ncurses_to_termcap.patch
+    - prefer_ncurses_to_termcap.patch [not win]
 
 build:
   number: 0
@@ -15,16 +15,18 @@ build:
 requirements:
   build:
     - python
+    - perl [win]
+    - gettext [win]
     - openssl
-    - ncurses 6.0
-    - readline
+    - ncurses 6.0 [not win]
+    - readline [not win]
     - libxml2
     - libxslt
   run:
     - python
     - openssl
-    - ncurses 6.0
-    - readline
+    - ncurses 6.0 [not win]
+    - readline [not win]
     - libxml2
     - libxslt
 

--- a/postgresql95/bld.bat
+++ b/postgresql95/bld.bat
@@ -1,0 +1,3 @@
+cd %SRC_DIR%\src\tools\msvc
+call build
+call install "%LIBRARY_PREFIX%"

--- a/postgresql95/build.sh
+++ b/postgresql95/build.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
 
+# this is required to get the build to work on OS X
+if [ "$OSX_ARCH" == "x86_64" ]; then
+  export LDFLAGS="$LDFLAGS -Wl,-rpath,$PREFIX/lib"
+  install_name_tool -id "@rpath/libreadline.6.2.dylib" $PREFIX/lib/libreadline.6.2.dylib
+fi
 ./configure \
     --prefix=$PREFIX       \
     --with-includes=$PREFIX/include \
@@ -18,6 +23,10 @@ make install
 pushd contrib
 make -j$CPU_COUNT
 # LD_LIBRARY_PATH required by hstore_plpython regression tests
+# make check may fail because of unix socket names
+# being too long depending on the length of the path
+# where anaconda is installed
+# add an --ignore-errors if this is the case
 LD_LIBRARY_PATH=$PREFIX/lib make check
 make install
 popd

--- a/postgresql95/meta.yaml
+++ b/postgresql95/meta.yaml
@@ -7,7 +7,7 @@ source:
   url: https://ftp.postgresql.org/pub/source/v9.5.2/postgresql-9.5.2.tar.bz2
   md5: c3f829b50f0351208debc79af3c946f9
   patches:
-    - prefer_ncurses_to_termcap.patch
+    - prefer_ncurses_to_termcap.patch [not win]
 
 build:
   number: 0
@@ -15,16 +15,19 @@ build:
 requirements:
   build:
     - python
+    - perl [win]
+    - gettext [win]
+    - zlib
     - openssl
-    - ncurses 6.0
-    - readline
+    - ncurses 6.0 [not win]
+    - readline [not win]
     - libxml2
     - libxslt
   run:
     - python
     - openssl
-    - ncurses 6.0
-    - readline
+    - ncurses 6.0 [not win]
+    - readline [not win]
     - libxml2
     - libxslt
 

--- a/rdkit-postgresql/bld.bat
+++ b/rdkit-postgresql/bld.bat
@@ -1,0 +1,45 @@
+%PYTHON% "%RECIPE_DIR%\pkg_version.py"
+
+cd "%SRC_DIR%\Code\PgSQL\rdkit"
+
+where jom 2> NUL
+if %ERRORLEVEL% equ 0 (
+    set MAKE_CMD=jom -j%CPU_COUNT%
+) else (
+    set MAKE_CMD=nmake
+)
+
+cmake ^
+    -G "NMake Makefiles" ^
+    -D CMAKE_SYSTEM_PREFIX_PATH=%LIBRARY_PREFIX% ^
+    -D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIXX% ^
+    -D CMAKE_BUILD_TYPE=Release ^
+    -D RDK_OPTIMIZE_NATIVE=ON ^
+    -D RDK_BUILD_AVALON_SUPPORT=ON ^
+    -D RDK_BUILD_INCHI_SUPPORT=ON ^
+    -D RDKit_DIR=%LIBRARY_PREFIX%\lib ^
+    .
+
+%MAKE_CMD%
+
+call pgsql_install.bat
+
+set PGPORT=54321
+set PGDATA=%SRC_DIR%\pgdata
+
+pg_ctl initdb
+
+rem ensure that the rdkit extension is loaded at process startup
+echo shared_preload_libraries = 'rdkit' >> %PGDATA%\postgresql.conf
+
+pg_ctl -D %PGDATA% -l %PGDATA%/log.txt start
+
+rem wait a few seconds just to make sure that the server has started
+timeout /t 2 /nobreak > NUL
+
+ctest -V
+set check_result=%ERRORLEVEL%
+
+pg_ctl stop
+
+exit /b %check_result%

--- a/rdkit-postgresql/meta.yaml
+++ b/rdkit-postgresql/meta.yaml
@@ -3,8 +3,8 @@ package:
   version: "__conda_version__"
 
 source:
-  git_url: https://github.com/rdkit/rdkit.git
-  git_rev: Release_2017_03_2
+  git_url: https://github.com/ptosco/rdkit.git
+  git_rev: master
   patches:
     - cmakelists.txt.patch
     - adapter.cpp.patch
@@ -16,11 +16,16 @@ requirements:
   build:
     - cmake
     - python
-    - rdkit >=2016.09
+    - msys2-conda-epoch >=20160418 [win]
+    - m2-msys2-runtime [win]
+    - m2-libiconv [win]
+    - m2-libintl [win]
+    - m2-diffutils [win]
+    - m2-patch [win]
     - postgresql >=9.4,<9.5
+    - rdkit >=2016.09
   run:
     - python
-    - rdkit >=2016.09
     - postgresql >=9.4,<9.5
 
 about:

--- a/rdkit-postgresql95/bld.bat
+++ b/rdkit-postgresql95/bld.bat
@@ -1,0 +1,47 @@
+rem %PYTHON% "%RECIPE_DIR%\pkg_version.py"
+
+cd "%SRC_DIR%\Code\PgSQL\rdkit"
+
+where jom 2> NUL
+if %ERRORLEVEL% equ 0 (
+    set MAKE_CMD=jom -j%CPU_COUNT%
+) else (
+    set MAKE_CMD=nmake
+)
+
+cmake ^
+    -G "NMake Makefiles" ^
+    -D CMAKE_SYSTEM_PREFIX_PATH=%LIBRARY_PREFIX% ^
+    -D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIXX% ^
+    -D CMAKE_BUILD_TYPE=Release ^
+    -D RDK_OPTIMIZE_NATIVE=ON ^
+    -D RDK_BUILD_AVALON_SUPPORT=ON ^
+    -D RDK_BUILD_INCHI_SUPPORT=ON ^
+    -D RDK_BUILD_CPP_TESTS=OFF ^
+    -D RDK_BUILD_PYTHON_WRAPPERS=OFF ^
+    -D RDKit_DIR=%LIBRARY_PREFIX%\lib ^
+    .
+
+%MAKE_CMD%
+
+call pgsql_install.bat
+
+set PGPORT=54321
+set PGDATA=%SRC_DIR%\pgdata
+
+pg_ctl initdb
+
+rem ensure that the rdkit extension is loaded at process startup
+echo shared_preload_libraries = 'rdkit' >> %PGDATA%\postgresql.conf
+
+pg_ctl -D %PGDATA% -l %PGDATA%/log.txt start
+
+rem wait a few seconds just to make sure that the server has started
+timeout /t 2 /nobreak > NUL
+
+ctest -V
+set check_result=%ERRORLEVEL%
+
+pg_ctl stop
+
+exit /b %check_result%

--- a/rdkit-postgresql95/meta.yaml
+++ b/rdkit-postgresql95/meta.yaml
@@ -3,8 +3,8 @@ package:
   version: "__conda_version__"
 
 source:
-  git_url: https://github.com/rdkit/rdkit.git
-  git_rev: Release_2017_03_2
+  git_url: https://github.com/ptosco/rdkit.git
+  git_rev: master
   patches:
     - cmakelists.txt.patch
     - adapter.cpp.patch
@@ -15,6 +15,12 @@ build:
 requirements:
   build:
     - cmake
+    - msys2-conda-epoch >=20160418 [win]
+    - m2-msys2-runtime [win]
+    - m2-libiconv [win]
+    - m2-libintl [win]
+    - m2-diffutils [win]
+    - m2-patch [win]
     - postgresql >=9.5
     - rdkit >=2017.03
   run:

--- a/rdkit/bld.bat
+++ b/rdkit/bld.bat
@@ -7,9 +7,16 @@ if "%PY_VER%"=="2.7" (
 	set PYTHON_LIBRARY=python35.lib
 ) else if  "%PY_VER%"=="3.6" (
 	set PYTHON_LIBRARY=python36.lib
-)else (
+) else (
 	echo "Unexpected version of python"
 	exit 1
+)
+
+where jom 2> NUL
+if %ERRORLEVEL% equ 0 (
+  set MAKE_CMD=jom -j%CPU_COUNT%
+) else (
+  set MAKE_CMD=nmake
 )
 
 cmake ^
@@ -28,14 +35,13 @@ cmake ^
     -D CMAKE_BUILD_TYPE=Release ^
     .
 
-nmake
+%MAKE_CMD%
 
 rem extend the environment settings in preparation to tests
 set RDBASE=%SRC_DIR%
 set PYTHONPATH=%RDBASE%
 
-nmake test
+%MAKE_CMD% test
 %PYTHON% "%RECIPE_DIR%\pkg_version.py"
 
-nmake install
-
+%MAKE_CMD% install

--- a/rdkit/meta.yaml
+++ b/rdkit/meta.yaml
@@ -3,8 +3,8 @@ package:
   version: "__conda_version__"
 
 source:
-  git_url: https://github.com/rdkit/rdkit.git
-  git_rev: Release_2017_03_2
+  git_url: https://github.com/ptosco/rdkit.git
+  git_rev: master
   patches:
     - rdpaths.patch
     - rdconfig.patch [win]
@@ -30,6 +30,7 @@ requirements:
     - pkg-config [unix]
     - eigen
     - pandas
+    - m2-patch [win]
   run:
     - boost ==1.56.0 [unix]
     - boost ==1.56.0 [win and py27]


### PR DESCRIPTION
Enables rdkit, rdkit-postgresql95 and rdkit-postgresql conda builds on all platforms.
I have tested it on the latest Anaconda release and it works on all platforms.
Please note that this PR requires https://github.com/rdkit/rdkit/pull/1455, https://github.com/rdkit/rdkit/pull/1456 and https://github.com/rdkit/rdkit/pull/1457.
Also note git points to https://github.com/ptosco/rdkit, but it should be reverted to https://github.com/ptosco/rdkit once the pull requests are merged in. The same applies to RDkit revisions.