### PR TITLE
Numerous updates 

### DIFF
--- a/boost/build.sh
+++ b/boost/build.sh
@@ -8,7 +8,7 @@
 # - bzip2-devel
 
 echo "PREFIX: " $PREFIX
-export CFLAGS="-m64 -pipe -O2 -march=x86-64 -fPIC -shared"
+export CFLAGS="-m64 -pipe -O2 -march=x86-64 -fPIC -shared";
 export CXXFLAGS="${CFLAGS}"
 
 export BZIP2_INCLUDE="${PREFIX}/include"
@@ -18,7 +18,7 @@ export ZLIB_LIBPATH="${PREFIX}/lib"
 
 ./bootstrap.sh --prefix="${PREFIX}/" --with-libraries=python,regex,thread,system,atomic,chrono,date_time,serialization;
 
-sed -i'.bak' -e's/^using python.*;//' ./project-config.jam
+sed -i'.bak' -e's/using python.*;//' ./project-config.jam
 
 PY_INC=`$PYTHON -c "from distutils import sysconfig; print (sysconfig.get_python_inc(0, '$PREFIX'))"`
 
@@ -36,7 +36,9 @@ if [ "$OSX_ARCH" == "x86_64" ] && ( echo $PY_VER | awk '{exit ($1 > 3.0 ? 0 : 1)
   cd $PREFIX/lib
   ln -s libpython${PY_VER}m.dylib libpython${PY_VER}.dylib
   cd $tmpd
+  export B2_EXTRAS='toolset=clang cxxflags="-stdlib=libc++" linkflags="-stdlib=libc++"'
 fi
-./b2 -q install \
+
+./b2 -q install $B2_EXTRAS \
      --with-python --with-regex --with-serialization --with-thread --with-system --with-atomic --with-chrono --with-date_time \
      --debug-configuration include=$PY_INC;

--- a/boost/build.sh
+++ b/boost/build.sh
@@ -36,6 +36,9 @@ if [ "$OSX_ARCH" == "x86_64" ] && ( echo $PY_VER | awk '{exit ($1 > 3.0 ? 0 : 1)
   cd $PREFIX/lib
   ln -s libpython${PY_VER}m.dylib libpython${PY_VER}.dylib
   cd $tmpd
+fi
+
+if [ "$OSX_ARCH" == "x86_64" ]; then
   export B2_EXTRAS='toolset=clang cxxflags="-stdlib=libc++" linkflags="-stdlib=libc++"'
 fi
 

--- a/boost/meta.yaml
+++ b/boost/meta.yaml
@@ -1,15 +1,15 @@
 
 package:
     name: boost
-    version: 1.61.0 [unix]
+    version: 1.63.0 [unix]
     version: 1.56.0 [win and py27]
     version: 1.56.0 [win and py34]
     version: 1.59.0 [win and py35]
     version: 1.59.0 [win and py36]
 
 source:
-    fn: boost_1_61_0.tar.bz2 [unix]
-    url: https://sourceforge.net/projects/boost/files/boost/1.61.0/boost_1_61_0.tar.bz2 [unix]
+    fn: boost_1_63_0.tar.bz2 [unix]
+    url: https://sourceforge.net/projects/boost/files/boost/1.63.0/boost_1_63_0.tar.bz2 [unix]
     fn: boost_1_56_0.zip [win and py27]
     url: http://downloads.sourceforge.net/project/boost/boost/1.56.0/boost_1_56_0.zip [win and py27]
     fn: boost_1_56_0.zip [win and py34]
@@ -20,19 +20,21 @@ source:
     url: http://downloads.sourceforge.net/project/boost/boost/1.59.0/boost_1_59_0.zip [win and py36]
 
 build:
-    number: 3
+    number: 1
 
 requirements:
     build:
+      - conda ==4.3.25
       - zlib
       - bzip2
       - python
-      - numpy >=1.11
+      - numpy >=1.12
     run:
+      - conda ==4.3.25
       - zlib
       - bzip2
       - python
-      - numpy >=1.11
+      - numpy >=1.12
 
 about:
     home: http://www.boost.org/

--- a/boost/meta.yaml
+++ b/boost/meta.yaml
@@ -30,7 +30,6 @@ requirements:
       - python
       - numpy >=1.12
     run:
-      - conda ==4.3.25
       - zlib
       - bzip2
       - python

--- a/boost/meta.yaml
+++ b/boost/meta.yaml
@@ -27,10 +27,12 @@ requirements:
       - zlib
       - bzip2
       - python
+      - numpy >=1.11
     run:
       - zlib
       - bzip2
       - python
+      - numpy >=1.11
 
 about:
     home: http://www.boost.org/

--- a/boost/meta.yaml
+++ b/boost/meta.yaml
@@ -3,7 +3,6 @@ package:
     name: boost
     version: 1.63.0 [unix]
     version: 1.56.0 [win and py27]
-    version: 1.56.0 [win and py34]
     version: 1.59.0 [win and py35]
     version: 1.59.0 [win and py36]
 
@@ -12,8 +11,6 @@ source:
     url: https://sourceforge.net/projects/boost/files/boost/1.63.0/boost_1_63_0.tar.bz2 [unix]
     fn: boost_1_56_0.zip [win and py27]
     url: http://downloads.sourceforge.net/project/boost/boost/1.56.0/boost_1_56_0.zip [win and py27]
-    fn: boost_1_56_0.zip [win and py34]
-    url: http://downloads.sourceforge.net/project/boost/boost/1.56.0/boost_1_56_0.zip [win and py34]
     fn: boost_1_59_0.zip [win and py35]
     url: http://downloads.sourceforge.net/project/boost/boost/1.59.0/boost_1_59_0.zip [win and py35]
     fn: boost_1_59_0.zip [win and py36]

--- a/rdkit-postgresql95/build.sh
+++ b/rdkit-postgresql95/build.sh
@@ -2,6 +2,9 @@
 
 cd $SRC_DIR/Code/PgSQL/rdkit
 
+if [ "$OSX_ARCH" == "x86_64" ]; then
+  export CXXFLAGS="-std=c++11 -stdlib=libc++"
+fi
 cmake \
     -D CMAKE_SYSTEM_PREFIX_PATH=$PREFIX \
     -D CMAKE_INSTALL_PREFIX=$PREFIX \

--- a/rdkit-postgresql95/meta.yaml
+++ b/rdkit-postgresql95/meta.yaml
@@ -4,7 +4,7 @@ package:
 
 source:
   git_url: https://github.com/rdkit/rdkit.git
-  git_rev: Release_2017_03
+  git_rev: Release_2017_09
   patches:
     - cmakelists.txt.patch
     - adapter.cpp.patch
@@ -22,7 +22,7 @@ requirements:
     - m2-diffutils [win]
     - m2-patch [win]
     - postgresql >=9.5
-    - rdkit >=2017.03
+    - rdkit >=2017.09
   run:
     - postgresql >=9.5
 

--- a/rdkit/build.sh
+++ b/rdkit/build.sh
@@ -2,7 +2,9 @@
 
 PY_INC=`$PYTHON -c "from distutils import sysconfig; print (sysconfig.get_python_inc(0, '$PREFIX'))"`
 
-#export CXXFLAGS="-std=c++11 -stdlib=libc++"
+if [ "$OSX_ARCH" == "x86_64" ]; then
+  export CXXFLAGS="-std=c++11 -stdlib=libc++"
+fi
 cmake \
     -D RDK_INSTALL_INTREE=OFF \
     -D RDK_INSTALL_STATIC_LIBS=OFF \

--- a/rdkit/build.sh
+++ b/rdkit/build.sh
@@ -2,6 +2,7 @@
 
 PY_INC=`$PYTHON -c "from distutils import sysconfig; print (sysconfig.get_python_inc(0, '$PREFIX'))"`
 
+#export CXXFLAGS="-std=c++11 -stdlib=libc++"
 cmake \
     -D RDK_INSTALL_INTREE=OFF \
     -D RDK_INSTALL_STATIC_LIBS=OFF \
@@ -21,12 +22,13 @@ cmake \
     -D CMAKE_BUILD_TYPE=Release \
     .
 
-make -j$CPU_COUNT
 
 if [[ `uname` == 'Linux' ]]; then
+    make -j$CPU_COUNT 
     RDBASE=$SRC_DIR LD_LIBRARY_PATH="$PREFIX/lib:$SRC_DIR/lib" PYTHONPATH=$SRC_DIR ctest -j$CPU_COUNT --output-on-failure
     RDBASE=$SRC_DIR LD_LIBRARY_PATH="$PREFIX/lib:$SRC_DIR/lib" PYTHONPATH=$SRC_DIR $PYTHON "$RECIPE_DIR/pkg_version.py"
 else
+    make -j$CPU_COUNT install
     RDBASE=$SRC_DIR DYLD_FALLBACK_LIBRARY_PATH="$PREFIX/lib:$SRC_DIR/lib" PYTHONPATH=$SRC_DIR ctest -j$CPU_COUNT --output-on-failure
     RDBASE=$SRC_DIR DYLD_FALLBACK_LIBRARY_PATH="$PREFIX/lib:$SRC_DIR/lib" PYTHONPATH=$SRC_DIR $PYTHON "$RECIPE_DIR/pkg_version.py"
 fi

--- a/rdkit/meta.yaml
+++ b/rdkit/meta.yaml
@@ -33,7 +33,6 @@ requirements:
     - pandas
     - m2-patch [win]
   run:
-    - conda ==4.3.25
     - boost ==1.63.0 [unix]
     - boost ==1.56.0 [win and py27]
     - boost ==1.56.0 [win and py34]

--- a/rdkit/meta.yaml
+++ b/rdkit/meta.yaml
@@ -19,7 +19,6 @@ requirements:
     - requests
     - boost ==1.63.0 [unix]
     - boost ==1.56.0 [win and py27]
-    - boost ==1.56.0 [win and py34]
     - boost ==1.59.0 [win and py35]
     - boost ==1.59.0 [win and py36]
     - python
@@ -35,7 +34,6 @@ requirements:
   run:
     - boost ==1.63.0 [unix]
     - boost ==1.56.0 [win and py27]
-    - boost ==1.56.0 [win and py34]
     - boost ==1.59.0 [win and py35]
     - boost ==1.59.0 [win and py36]
     - cairo [unix]

--- a/rdkit/meta.yaml
+++ b/rdkit/meta.yaml
@@ -14,20 +14,16 @@ build:
 
 requirements:
   build:
+    - conda ==4.3.25
     - cmake
     - requests
-    - boost ==1.61 [osx]
-    - boost ==1.61.0 [linux]
+    - boost ==1.63.0 [unix]
     - boost ==1.56.0 [win and py27]
     - boost ==1.56.0 [win and py34]
     - boost ==1.59.0 [win and py35]
     - boost ==1.59.0 [win and py36]
-    - python [linux]
-    - python [win]
-    - python ==3.5.2 [osx and py35]
-    - python [osx and py27]
-    - python ==3.6.1 [osx and py36]
-    - numpy >=1.13
+    - python
+    - numpy >=1.12
     - pillow
     - freetype
     - nox [unix]
@@ -37,22 +33,17 @@ requirements:
     - pandas
     - m2-patch [win]
   run:
-    - boost ==1.61 [osx]
-    - boost ==1.61.0 [linux]
+    - conda ==4.3.25
+    - boost ==1.63.0 [unix]
     - boost ==1.56.0 [win and py27]
     - boost ==1.56.0 [win and py34]
     - boost ==1.59.0 [win and py35]
     - boost ==1.59.0 [win and py36]
     - cairo [unix]
-    - python [linux]
-    - python [win]
-    - python ==3.5.2 [osx and py35]
-    - python [osx and py27]
-    - python ==3.6.1 [osx and py36]
+    - python 
     - pillow
     - pandas
-    - numpy >=1.13
-
+    - numpy >=1.12
 test:
   imports:
     - rdkit

--- a/rdkit/meta.yaml
+++ b/rdkit/meta.yaml
@@ -4,7 +4,7 @@ package:
 
 source:
   git_url: https://github.com/rdkit/rdkit.git
-  git_rev: Release_2017_03
+  git_rev: master 
   patches:
     - rdpaths.patch
     - rdconfig.patch [win]
@@ -16,13 +16,18 @@ requirements:
   build:
     - cmake
     - requests
-    - boost ==1.61.0 [unix]
+    - boost ==1.61 [osx]
+    - boost ==1.61.0 [linux]
     - boost ==1.56.0 [win and py27]
     - boost ==1.56.0 [win and py34]
     - boost ==1.59.0 [win and py35]
     - boost ==1.59.0 [win and py36]
-    - python
-    - numpy >=1.11
+    - python [linux]
+    - python [win]
+    - python ==3.5.2 [osx and py35]
+    - python [osx and py27]
+    - python ==3.6.1 [osx and py36]
+    - numpy >=1.13
     - pillow
     - freetype
     - nox [unix]
@@ -32,16 +37,21 @@ requirements:
     - pandas
     - m2-patch [win]
   run:
-    - boost ==1.61.0 [unix]
+    - boost ==1.61 [osx]
+    - boost ==1.61.0 [linux]
     - boost ==1.56.0 [win and py27]
     - boost ==1.56.0 [win and py34]
     - boost ==1.59.0 [win and py35]
     - boost ==1.59.0 [win and py36]
     - cairo [unix]
-    - python
+    - python [linux]
+    - python [win]
+    - python ==3.5.2 [osx and py35]
+    - python [osx and py27]
+    - python ==3.6.1 [osx and py36]
     - pillow
     - pandas
-    - numpy >=1.11
+    - numpy >=1.13
 
 test:
   imports:

--- a/rdkit/meta.yaml
+++ b/rdkit/meta.yaml
@@ -4,7 +4,7 @@ package:
 
 source:
   git_url: https://github.com/rdkit/rdkit.git
-  git_rev: master 
+  git_rev: Release_2017_09
   patches:
     - rdpaths.patch
     - rdconfig.patch [win]


### PR DESCRIPTION
Some of the changes here:

- Use rdkit master instead of a particular release. We should be sure to change this before merging to master
- Switch the linux and mac builds to boost 1.63
- Pin the conda version in an attempt to avoid their new builds

I've tested the full thing on the Mac and on CentOS6 with py36 (py35 seems to always be the same) and py27. 
Most of this has also been tested on windows, but I will confirm that again.

I have not updated the other pieces, the cartridge build in particular, but that should also be done.
