### PR TITLE
speed up postgresql builds

### DIFF
--- a/rdkit-postgresql/build.sh
+++ b/rdkit-postgresql/build.sh
@@ -1,6 +1,7 @@
-rm -rf build # cleanup required when building variants
-mkdir build
+mkdir -p build
 cd build
+# in case there are any old psql builds: remove them
+rm -rf Code/PgSQL
 
 cmake \
     -D RDK_BUILD_PGSQL=ON \


### PR DESCRIPTION
@rvianello : this speeds up the postgresql builds dramatically since the full RDKit doesn't need to be built again for each different psql version. I don't think it should screw anything up, but please take a look.