### PR TITLE
Adds travis-ci builds to conda-rdkit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+language: python
+python:
+  # We don't actually use the Travis Python, but this keeps it organized.
+  - "3.6"
+  #- "2.7"
+install:
+  - sudo apt-get update
+  # We do this conditionally because it saves us some downloading if the
+  # version is the same.
+  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
+      wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
+    else
+      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+    fi
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - hash -r
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update -q conda
+  # Useful for debugging any issues with conda
+  - conda info -a
+
+  # Replace dep1 dep2 ... with your dependencies
+  - conda install cmake git patch conda-build boost boost-cpp numpy=1.12 gxx_linux-64 gcc_linux-64
+  - source activate base && conda build nox
+  - source activate base && conda build cairo_nox
+  - source activate base && conda build rdkit
+
+script:
+  # Your test script goes here

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,14 @@ install:
   - conda info -a
 
   # Replace dep1 dep2 ... with your dependencies
-  - conda install cmake git patch conda-build boost boost-cpp numpy=1.12 gxx_linux-64 gcc_linux-64
+  - conda install cmake git patch conda-build anaconda-client boost boost-cpp numpy=1.12 gxx_linux-64 gcc_linux-64
+
+script:
+  # do the build:
   - source activate base && conda build nox
   - source activate base && conda build cairo_nox
   - source activate base && conda build rdkit
 
-script:
-  # Your test script goes here
+after_success:
+  - anaconda -t $CONDA_UPLOAD_TOKEN upload -u greglandrum -l nightly $HOME/miniconda/conda-bld/$TRAVIS_OS_NAME-64/rdkit*.tar.bz2
+  

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,5 +30,4 @@ script:
   - source activate base && conda build rdkit
 
 after_success:
-  - anaconda -t $CONDA_UPLOAD_TOKEN upload -u greglandrum -l nightly $HOME/miniconda/conda-bld/$TRAVIS_OS_NAME-64/rdkit*.tar.bz2
-  
+  - anaconda -t $CONDA_UPLOAD_TOKEN upload --no-progress -u rdkit -l nightly $HOME/miniconda/conda-bld/$TRAVIS_OS_NAME-64/rdkit*.tar.bz2

--- a/rdkit/meta.yaml
+++ b/rdkit/meta.yaml
@@ -5,7 +5,7 @@ package:
 
 source:
   git_url: https://github.com/rdkit/rdkit.git
-  git_rev: Release_2018_03
+  git_rev: master
   patches:
     - rdpaths.patch
     - rdconfig.patch [win]

--- a/rdkit/meta.yaml
+++ b/rdkit/meta.yaml
@@ -1,7 +1,11 @@
 package:
   name: rdkit
+  # This is the real version, used in releases:
   # version is the last TAG + the number of commits since
-  version: {{ environ.get('GIT_DESCRIBE_TAG', 'LOCAL').replace("_", ".").replace("Release.","") }}.{{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}
+  # version: {{ environ.get('GIT_DESCRIBE_TAG', 'LOCAL').replace("_", ".").replace("Release.","") }}.{{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}
+  # This is the version used for the nightlies:
+  version: 2018.09.1pre.{{ environ.get('GIT_DESCRIBE_NUMBER', 1) }}
+
 
 source:
   git_url: https://github.com/rdkit/rdkit.git


### PR DESCRIPTION
This currently just does rdkit (not the cartridge), and there's still a bit of ugliness in the way the version number is constructed, but this allows us to use travis-ci + conda to do build and automatically deploy linux builds of master. I think it's pretty cool and potentially quite useful. 

The deployed files end up here: https://anaconda.org/rdkit/repo/files?type=any&label=nightly