### PR TITLE
pin the runtime dependency from the boost libraries

### DIFF
--- a/rdkit-postgresql/conda_build_config.yaml
+++ b/rdkit-postgresql/conda_build_config.yaml
@@ -3,5 +3,9 @@ postgresql:
   - 9.6
   - 10
 
+libboost: 1.65.1
+
 pin_run_as_build:
   postgresql: x.x
+  libboost:
+    max_pin: x.x

--- a/rdkit-postgresql/meta.yaml
+++ b/rdkit-postgresql/meta.yaml
@@ -16,7 +16,8 @@ requirements:
     - cmake
     - python
   host:
-    - boost-cpp ==1.65.1
+    - libboost {{ libboost }}
+    - boost-cpp
     - eigen
     - msys2-conda-epoch >=20160418 [win]
     - m2-msys2-runtime [win]

--- a/rdkit/conda_build_config.yaml
+++ b/rdkit/conda_build_config.yaml
@@ -1,2 +1,7 @@
 CONDA_BUILD_SYSROOT:
   - /opt/MacOSX10.9.sdk   [osx]
+
+libboost: 1.65.1
+pin_run_as_build:
+  libboost:
+    max_pin: x.x

--- a/rdkit/meta.yaml
+++ b/rdkit/meta.yaml
@@ -25,8 +25,9 @@ requirements:
     - m2-patch [win]
     - cmake
   host:
-    - boost-cpp ==1.65.1
-    - py-boost ==1.65.1
+    - libboost {{ libboost }}
+    - boost-cpp
+    - py-boost
     - python
     - numpy ==1.12
     - pillow
@@ -38,7 +39,8 @@ requirements:
     - eigen
     - pandas <=0.22.0
   run:
-    - py-boost ==1.65.1
+    - libboost
+    - py-boost
     - cairo
     - python
     - pillow


### PR DESCRIPTION
I think this could be one of the possible ways to address #71. In practice, the version requirements are defined on the libboost package, and based on these constraints, conda is expected to pick suitable boost-cpp and py-boost packages.

(I only tested the build on linux for python3, but I don't think these changes may be very specific to any build configuration).