### PR TITLE
be less specific about the boost version

### DIFF
--- a/rdkit/conda_build_config.yaml
+++ b/rdkit/conda_build_config.yaml
@@ -1,7 +1,7 @@
 CONDA_BUILD_SYSROOT:
   - /opt/MacOSX10.9.sdk   [osx]
 
-libboost: 1.65.1
+libboost: 1.65
 pin_run_as_build:
   libboost:
     max_pin: x.x


### PR DESCRIPTION
by specifying 1.65 we allow the max_pin to work properly