### PR TITLE
Fixes broken PostgreSQL cartridge build on Windows

### DIFF
--- a/rdkit-postgresql/bld.bat
+++ b/rdkit-postgresql/bld.bat
@@ -1,6 +1,35 @@
 %PYTHON% "%RECIPE_DIR%\pkg_version.py"
 
-cd "%SRC_DIR%\Code\PgSQL\rdkit"
+cd "%SRC_DIR%"
+
+rmdir /s /q build 2> NUL
+mkdir build
+cd build
+:: in case there are any old psql builds: remove them
+rmdir /s /q Code\PgSQL 2> NUL
+
+cmake ^
+    -G "NMake Makefiles" ^
+    -D RDK_BUILD_PGSQL=ON ^
+    -D RDK_PGSQL_STATIC=ON ^
+    -D RDK_INSTALL_INTREE=OFF ^
+    -D RDK_INSTALL_STATIC_LIBS=OFF ^
+    -D RDK_INSTALL_DEV_COMPONENT=OFF ^
+    -D RDK_BUILD_INCHI_SUPPORT=ON ^
+    -D RDK_BUILD_AVALON_SUPPORT=ON ^
+    -D RDK_BUILD_FREESASA_SUPPORT=OFF ^
+    -D RDK_USE_FLEXBISON=OFF ^
+    -D RDK_BUILD_THREADSAFE_SSS=ON ^
+    -D RDK_TEST_MULTITHREADED=ON ^
+    -D RDK_OPTIMIZE_NATIVE=ON ^
+    -D RDK_BUILD_CPP_TESTS=OFF ^
+    -D RDK_BUILD_PYTHON_WRAPPERS=OFF ^
+    -D RDK_USE_BOOST_SERIALIZATION=OFF ^
+    -D CMAKE_SYSTEM_PREFIX_PATH=%LIBRARY_PREFIX% ^
+    -D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
+    -D BOOST_ROOT=%PREFIX% -D Boost_NO_SYSTEM_PATHS=ON ^
+    -D CMAKE_BUILD_TYPE=Release ^
+    ..
 
 where jom 2> NUL
 if %ERRORLEVEL% equ 0 (
@@ -9,19 +38,9 @@ if %ERRORLEVEL% equ 0 (
     set MAKE_CMD=nmake
 )
 
-cmake ^
-    -G "NMake Makefiles" ^
-    -D CMAKE_SYSTEM_PREFIX_PATH=%LIBRARY_PREFIX% ^
-    -D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIXX% ^
-    -D CMAKE_BUILD_TYPE=Release ^
-    -D RDK_OPTIMIZE_NATIVE=ON ^
-    -D RDK_BUILD_AVALON_SUPPORT=ON ^
-    -D RDK_BUILD_INCHI_SUPPORT=ON ^
-    -D RDKit_DIR=%LIBRARY_PREFIX%\lib ^
-    .
-
 %MAKE_CMD%
 
+cd Code\PgSQL\rdkit
 call pgsql_install.bat
 
 set PGPORT=54321
@@ -35,8 +54,9 @@ echo shared_preload_libraries = 'rdkit' >> %PGDATA%\postgresql.conf
 pg_ctl -D %PGDATA% -l %PGDATA%/log.txt start
 
 rem wait a few seconds just to make sure that the server has started
-timeout /t 2 /nobreak > NUL
+ping -n 5 127.0.0.1 > NUL
 
+set "RDBASE=%SRC_DIR%"
 ctest -V
 set check_result=%ERRORLEVEL%
 

--- a/rdkit-postgresql/iostreams.patch
+++ b/rdkit-postgresql/iostreams.patch
@@ -1,0 +1,23 @@
+--- Code/PgSQL/rdkit/CMakeLists.txt	2019-12-26 15:35:18.050820200 +0100
++++ Code/PgSQL/rdkit/CMakeLists.txt	2019-12-26 15:57:33.296451700 +0100
+@@ -15,8 +15,10 @@
+ endif(RDK_OPTIMIZE_NATIVE)
+ 
+ set(EXTENSION rdkit)
++set(Boost_USE_STATIC_LIBS OFF)
++set(BUILD_SHARED_LIBS ON)
+ if(NOT DEFINED Boost_INCLUDE_DIRS)
+-  find_package(Boost 1.56.0 REQUIRED)
++  find_package(Boost 1.56.0 COMPONENTS iostreams REQUIRED)
+ endif(NOT DEFINED Boost_INCLUDE_DIRS)
+ include_directories(${Boost_INCLUDE_DIRS})
+ message("postgres: ${PostgreSQL_INCLUDE_DIRS}")
+@@ -82,7 +84,7 @@
+   add_library(${EXTENSION} SHARED
+               adapter.cpp bfp_op.c cache.c guc.c low_gist.c mol_op.c
+               rdkit_gist.c bfp_gist.c bfp_gin.c bitstring.c rdkit_io.c rxn_op.c sfp_op.c)
+-  target_link_libraries(${EXTENSION} ${PostgreSQL_LIBRARIES})
++  target_link_libraries(${EXTENSION} Boost::iostreams ${PostgreSQL_LIBRARIES})
+   if(WIN32)
+     target_link_libraries(${EXTENSION} postgres)
+   endif(WIN32)

--- a/rdkit-postgresql/meta.yaml
+++ b/rdkit-postgresql/meta.yaml
@@ -5,6 +5,8 @@ package:
 source:
   git_url: https://github.com/rdkit/rdkit.git
   git_rev: Release_2019_09
+  patches:
+    - iostreams.patch [win]
 
 build:
   number: 0


### PR DESCRIPTION
Currently the `conda` build of the PostgreSQL cartridge is broken on Windows. This PR allows building the PostgreSQL cartridge on WIndows.