### PR TITLE
[WIP] Build RDKIT with python 3.8

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,6 +13,8 @@ jobs:
     vmImage: ubuntu-18.04
   strategy:
     matrix:
+      Python38:
+        python.version: '38'
       Python37:
         python.version: '37'
       Python36:
@@ -28,6 +30,8 @@ jobs:
   strategy:
     matrix:
       Python37:
+        python.version: '38'
+      Python37:
         python.version: '37'
       Python36:
         python.version: '36'
@@ -40,6 +44,8 @@ jobs:
     vmImage: vs2017-win2016
   strategy:
     matrix:
+      Python37:
+        python.version: '38'
       Python37:
         python.version: '37'
       Python36:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,7 +29,7 @@ jobs:
     target_platform: 10.9
   strategy:
     matrix:
-      Python37:
+      Python38:
         python.version: '38'
       Python37:
         python.version: '37'
@@ -44,7 +44,7 @@ jobs:
     vmImage: vs2017-win2016
   strategy:
     matrix:
-      Python37:
+      Python38:
         python.version: '38'
       Python37:
         python.version: '37'

--- a/rdkit/conda_build_config.yaml
+++ b/rdkit/conda_build_config.yaml
@@ -1,7 +1,7 @@
 CONDA_BUILD_SYSROOT:
   - /opt/MacOSX10.9.sdk   [osx]
 
-libboost: 1.67
+libboost: 1.71
 pin_run_as_build:
   libboost:
     max_pin: x.x

--- a/rdkit/meta.yaml
+++ b/rdkit/meta.yaml
@@ -35,7 +35,7 @@ requirements:
     - cairo
     - pkg-config [unix]
     - eigen
-    - pandas <=0.24.0
+    - pandas
   run:
     - libboost
     - py-boost


### PR DESCRIPTION
Python 3.8 is out as of October 14th 2019.
https://www.python.org/downloads/release/python-380/

More and more packages will be using this version over time.  We should see if the RDKit can support python 3.8.

Note: python 3.6 will be EOL in 2021 so we should keep it around until then.

I don't know if the azure-pipelines are hooked up to run on PR's but this is an attempt to see what happens when attempting to build python 3.8 on all the systems.